### PR TITLE
docs: add invoice RAG project documentation

### DIFF
--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -1,0 +1,116 @@
+# Invoice Assistant API Design
+
+This document separates the current FastAPI endpoints from the proposed SaaS and
+invoice RAG API direction. Current endpoints are implemented in the repository.
+Proposed endpoints are planning contracts only and are not added by this
+documentation change.
+
+## Quick path
+
+1. Use Current endpoints for behavior that exists today.
+2. Treat authentication, tenant-scoped invoice retrieval, invoice chat, and RAG
+   response contracts as **Proposed**.
+3. Do not add placeholder routes until the related implementation slice exists.
+
+## Current endpoints
+
+| Endpoint | Current purpose | Request shape | Response shape | Evidence |
+|----------|-----------------|---------------|----------------|----------|
+| `GET /health` | Health check. | None. | `{"status": "ok"}` | `app/api/routes.py` |
+| `POST /summarize` | Generic text summarization through Anthropic. | `SummarizeRequest` JSON body. | `SummarizeResponse` | `app/api/routes.py`, `app/schemas/ai.py` |
+| `POST /chat/stream` | Generic prompt streaming. | `prompt` parameter. | `text/plain` stream. | `app/api/chat.py` |
+| `POST /agent/stream` | Generic Claude agent loop streaming. | `prompt` parameter. | `text/plain` stream. | `app/api/agent.py` |
+| `POST /invoice/upload` | SAT invoice spreadsheet upload and optional AI batch summary. | Multipart file plus `invoiceType` form field. | `UploadResult` | `app/api/invoices.py`, `app/schemas/response.py` |
+
+## Current invoice upload contract
+
+```text
+POST /invoice/upload
+Content-Type: multipart/form-data
+
+file: UploadFile
+invoiceType: expenses | incomes
+```
+
+`UploadResult` currently includes:
+
+| Field | Current meaning |
+|-------|-----------------|
+| `batch_id` | Upload batch identifier. |
+| `filename` | Uploaded filename or `unknown`. |
+| `invoice_type` | Stored invoice type string. |
+| `total_rows` | Number of validated rows. |
+| `total_amount` | Sum of row totals. |
+| `total_iva` | Sum of IVA values. |
+| `status` | Batch processing status. |
+| `uploaded_at` | Batch upload timestamp. |
+| `ai_summary` | Optional structured AI summary; may be absent if analysis fails. |
+
+## Current limitations
+
+- No authentication or tenant context is accepted by current routes.
+- No current endpoint lists, filters, or fetches persisted invoices after upload.
+- No current endpoint retrieves invoice documents, chunks, embeddings, or
+  citations.
+- Current `/chat/stream` and `/agent/stream` do not query invoice repositories.
+
+## Proposed API principles
+
+| Principle | Proposed rule |
+|-----------|---------------|
+| Auth first | Every invoice read, upload, and chat route should require authenticated context. |
+| Tenant scoped | Routes should derive tenant scope from membership, not from trusted client-provided filters alone. |
+| Retrieval transparency | RAG responses should expose citations and retrieval metadata. |
+| Backward-safe upload | Existing upload behavior should evolve without breaking current response fields. |
+| Reviewable slices | Add routes only with tests and authorization checks in the same implementation slice. |
+
+## Proposed endpoint direction
+
+| Endpoint | Proposed purpose | Notes |
+|----------|------------------|-------|
+| `POST /auth/...` | Sign in and session/token management. | Exact auth mechanism is undecided. |
+| `GET /tenants/{tenant_id}/invoices` | List authorized invoice facts with filters. | Requires tenant membership checks. |
+| `GET /tenants/{tenant_id}/invoices/{invoice_id}` | Fetch one invoice and related tax detail. | Must verify invoice belongs to tenant. |
+| `POST /tenants/{tenant_id}/invoice-chat` | Ask a grounded question over tenant invoices. | Returns answer plus citations. |
+| `GET /tenants/{tenant_id}/uploads/{batch_id}` | Inspect upload status and totals. | Extends current upload batch concept. |
+| `GET /tenants/{tenant_id}/documents/{document_id}` | Fetch source document metadata. | Proposed only after object storage exists. |
+
+## Proposed invoice chat response shape
+
+```json
+{
+  "answer": "The answer grounded in authorized invoice evidence.",
+  "citations": [
+    {
+      "source_type": "invoice",
+      "source_id": "uuid",
+      "label": "Invoice ABC-123 from Vendor S.A.",
+      "excerpt": "Total: 1200.00, IVA: 144.00",
+      "confidence": 0.92
+    }
+  ],
+  "retrieval": {
+    "tenant_id": "uuid",
+    "result_count": 3,
+    "strategy": "structured_filter_plus_vector"
+  }
+}
+```
+
+This shape is **Proposed**. No current route returns it.
+
+## Proposed error semantics
+
+| Case | Proposed response |
+|------|-------------------|
+| Missing authentication | `401 Unauthorized`. |
+| Tenant membership missing | `403 Forbidden`. |
+| Invoice/document outside tenant | `404 Not Found` or `403 Forbidden`, chosen consistently. |
+| No supporting evidence | Successful answer that explains no authorized evidence was found. |
+| Ingestion not ready | `409 Conflict` or status response indicating the upload is still processing. |
+
+## Non-goals for this documentation change
+
+- No route, schema, dependency, auth middleware, repository method, or runtime
+  behavior is added.
+- No current endpoint is reclassified as invoice RAG.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,118 @@
+# Invoice Assistant Architecture
+
+This document describes the architecture that exists today and the SaaS/RAG
+architecture the product can evolve toward. **Current** means implemented in the
+repository. **Proposed** means future direction only.
+
+## Quick path
+
+1. Use the Current architecture map to understand the running FastAPI app.
+2. Use the Current flows to verify invoice upload, AI summary, and generic chat
+   behavior.
+3. Treat every SaaS, tenant, vector, retrieval, or invoice chat reference as
+   **Proposed** unless this document marks it Current with source evidence.
+
+## Current architecture map
+
+The application uses a layered FastAPI structure with dependency injection at
+the API boundary.
+
+```text
+app/main.py
+  -> app/api/                  FastAPI routers
+  -> app/services/             business workflows and AI orchestration
+  -> app/infrastructure/       database, repositories, Anthropic client factory
+  -> app/models/               SQLModel tables and Pydantic domain models
+  -> app/schemas/              request/response DTOs
+  -> app/utils/                Anthropic stream parsing helpers
+```
+
+| Layer | Current responsibility | Evidence |
+|-------|------------------------|----------|
+| API | Mounts `/health`, `/summarize`, `/chat/stream`, `/agent/stream`, and `/invoice/upload`. | `app/main.py`, `app/api/routes.py`, `app/api/chat.py`, `app/api/agent.py`, `app/api/invoices.py` |
+| Services | Parse SAT files, validate invoice rows, persist batches, call Anthropic for summaries, stream generic chat, and run the agent loop. | `app/services/invoice_service.py`, `app/services/invoice_ai_service.py`, `app/services/llm_service.py`, `app/services/ll_stream_service.py`, `app/agents/agent_loop.py` |
+| Infrastructure | Creates the async database engine/session, repository objects, and Anthropic client. | `app/infrastructure/database.py`, `app/infrastructure/repositories.py`, `app/infrastructure/anthropic_client.py` |
+| Models | Defines upload batches, companies, invoices, invoice tax details, invoice row validation, and AI summary shapes. | `app/models/db_models.py`, `app/models/invoice.py` |
+
+## Current invoice upload flow
+
+```text
+POST /invoice/upload
+  -> app/api/invoices.py reads UploadFile and invoiceType
+  -> InvoiceService.process_sat_file reads Excel bytes with pandas
+  -> SAT columns are renamed to internal field names
+  -> each row is validated as InvoiceRowSchema
+  -> UploadBatch, Company, Invoice, and InvoiceTaxDetail rows are persisted
+  -> batch totals and status are committed
+  -> InvoiceAIService attempts a structured Anthropic summary
+  -> UploadResult returns totals, status, timestamp, and optional ai_summary
+```
+
+| Step | Current behavior | Evidence |
+|------|------------------|----------|
+| Upload input | The route accepts `file: UploadFile` and `invoiceType: InvoiceType` from form data. | `app/api/invoices.py` |
+| File parsing | `.xls` uses `xlrd`; other Excel files use `openpyxl`; pandas reads the uploaded bytes. | `app/services/invoice_service.py` |
+| Column normalization | Spanish SAT column names are renamed by `COLUMN_RENAME_MAP`. | `app/services/invoice_service.py` |
+| Validation | Rows are validated with `InvoiceRowSchema`; invalid rows raise HTTP 400. | `app/services/invoice_service.py`, `tests/test_invoice_service.py` |
+| Persistence | The service creates or reuses companies, creates invoices and tax details, updates the upload batch, then commits. | `app/services/invoice_service.py`, `app/infrastructure/repositories.py`, `tests/test_repositories.py` |
+| Response | `UploadResult` includes `batch_id`, filename, invoice type, totals, status, upload timestamp, and optional `ai_summary`. | `app/schemas/response.py` |
+| AI failure handling | If AI analysis fails after upload processing, the route logs a warning and returns the upload result without a summary. | `app/api/invoices.py`, `tests/test_invoice_upload.py` |
+
+## Current generic AI flows
+
+These endpoints are implemented, but they are not invoice RAG endpoints.
+
+| Endpoint | Current flow | Invoice data access? | Evidence |
+|----------|--------------|----------------------|----------|
+| `POST /summarize` | Builds a summary prompt and calls Anthropic messages API through `LLMService`. | No. | `app/api/routes.py`, `app/services/llm_service.py` |
+| `POST /chat/stream` | Streams a single prompt through Anthropic and yields text chunks. | No. | `app/api/chat.py`, `app/services/ll_stream_service.py` |
+| `POST /agent/stream` | Runs a Claude tool-use loop and dispatches tools through the registry. | No invoice-specific tools are present. | `app/api/agent.py`, `app/agents/agent_loop.py`, `app/agents/tools.py` |
+
+## Current persistence and startup
+
+- `app/main.py` initializes the database during FastAPI lifespan startup.
+- `app/infrastructure/database.py` builds an async SQLAlchemy engine from
+  `settings.database_url` and exposes `get_session()` for dependency injection.
+- SQLModel metadata is created at startup through `init_db()`.
+- Repository methods use the injected `AsyncSession`; commit control remains in
+  `InvoiceService._process_validated_rows()` for the invoice upload workflow.
+
+## Proposed SaaS/RAG evolution
+
+The target architecture is a multi-user SaaS invoice assistant with grounded
+invoice Q&A. None of the components below are implemented by this documentation
+change.
+
+| Proposed area | Proposed responsibility | Current status |
+|---------------|-------------------------|----------------|
+| Authentication | Identify users before upload, retrieval, or chat. | **Proposed** — no auth middleware, user model, or session contract exists. |
+| Tenant isolation | Scope invoices, uploads, documents, chunks, and chat sessions by tenant/user. | **Proposed** — current persisted invoice records have no tenant key. |
+| Object storage | Store original uploaded files outside the relational invoice tables. | **Proposed** — no object storage client or document table exists. |
+| Ingestion jobs | Turn uploaded files into durable documents, chunks, embeddings, and searchable metadata. | **Proposed** — current upload parses structured rows only. |
+| Vector retrieval | Search tenant-authorized chunks and structured invoice facts before answering. | **Proposed** — no embedding model, vector index, or retriever exists. |
+| Grounded invoice chat | Answer invoice questions with citations and retrieval metadata. | **Proposed** — current chat streams from a raw prompt only. |
+
+## Proposed target flow
+
+```text
+Authenticated user uploads invoice file
+  -> tenant ownership is checked
+  -> current structured SAT parsing persists invoice facts
+  -> proposed document storage saves the original upload
+  -> proposed ingestion jobs create chunks and embeddings
+  -> proposed invoice chat retrieves authorized facts/chunks
+  -> proposed answer generation cites source invoices/documents
+```
+
+## Non-goals for this documentation slice
+
+- No application code, endpoint, database, migration, or runtime behavior change.
+- No placeholder auth, tenant, document, embedding, vector, or RAG implementation.
+- No claim that current generic chat can retrieve invoice records.
+
+## Current claim cross-check
+
+The Current claims in this document were checked against `app/api/`,
+`app/services/`, `app/infrastructure/`, `app/models/`, `app/schemas/`, and the
+invoice/repository tests. Future SaaS and RAG behavior remains labeled
+**Proposed** because those components were not found in the inspected code.

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -1,0 +1,138 @@
+# Invoice Assistant Domain Model
+
+This document explains the domain concepts that exist today and the domain
+concepts needed for the proposed SaaS/RAG direction. **Current** means the model
+is implemented in code. **Proposed** means future design only.
+
+## Quick path
+
+1. Use Current invoice models when changing upload, validation, or persistence.
+2. Use Proposed models only when planning future SaaS/RAG work.
+3. Do not assume current data has user ownership, tenant isolation, source
+   documents, chunks, embeddings, or citations.
+
+## Current domain summary
+
+| Concept | Current role | Evidence |
+|---------|--------------|----------|
+| `InvoiceType` | Accepts `expenses` and `incomes` as upload categories. | `app/models/invoice.py`, `app/api/invoices.py` |
+| `InvoiceRowSchema` | Validates normalized SAT spreadsheet rows before persistence. | `app/models/invoice.py`, `app/services/invoice_service.py` |
+| `UploadBatch` | Tracks one uploaded file, invoice type, totals, status, and upload timestamp. | `app/models/db_models.py` |
+| `Company` | Represents the invoice issuer/vendor keyed by unique NIT. | `app/models/db_models.py`, `app/infrastructure/repositories.py` |
+| `Invoice` | Stores validated invoice facts linked to an upload batch and company. | `app/models/db_models.py` |
+| `InvoiceTaxDetail` | Stores per-invoice tax detail amounts. | `app/models/db_models.py` |
+| `InvoiceSummary` | Pydantic response model for Anthropic batch analysis. | `app/models/invoice.py`, `app/services/invoice_ai_service.py` |
+| `UploadResult` | API response for invoice upload totals and optional AI summary. | `app/schemas/response.py` |
+
+## Current entity relationships
+
+```text
+UploadBatch 1 ── * Invoice * ── 1 Company
+Invoice    1 ── 0..1 InvoiceTaxDetail
+```
+
+| Relationship | Current behavior | Evidence |
+|--------------|------------------|----------|
+| Batch to invoices | Each invoice stores `batch_id`; `UploadBatch.invoices` is a relationship. | `app/models/db_models.py` |
+| Company to invoices | Each invoice stores `company_id`; companies are reused by unique NIT. | `app/models/db_models.py`, `app/infrastructure/repositories.py` |
+| Invoice to tax detail | Each tax detail stores a unique `invoice_id`. | `app/models/db_models.py` |
+
+## Current validation model
+
+`InvoiceRowSchema` is the boundary between a normalized spreadsheet row and the
+persistence workflow.
+
+| Field group | Current examples | Notes |
+|-------------|------------------|-------|
+| Identity | `authorization_number`, `serie`, `dte_number`, `dte_type` | Stored on `Invoice`. |
+| Dates and status | `date`, `state`, `is_voided`, `voided_date` | `is_voided` converts the SAT value `No` to `False`; other values become `True`. |
+| Issuer/company | `company_nit`, `company_name`, `company_description`, `company_code` | `company_nit` is converted to string and used for company reuse. |
+| Customer/certifier | `customer_nit`, `customer_name`, `certificator_nit`, `certificator_name` | NIT-like fields are converted to strings. |
+| Amounts | `total`, `iva`, and specific tax fields | Totals feed `UploadResult` and `UploadBatch`. |
+
+## Current upload aggregate
+
+During upload processing, the service builds an aggregate around one
+`UploadBatch`:
+
+1. Create the batch with `processing` status.
+2. Reuse or create `Company` rows for validated issuer NITs.
+3. Create `Invoice` rows for each validated invoice.
+4. Create `InvoiceTaxDetail` rows for each invoice.
+5. Update batch totals and mark the batch `completed`.
+6. Commit the transaction and return `UploadResult`.
+
+The tests cover row validation, repository creation/reuse, tax detail creation,
+and upload behavior with AI summary failure.
+
+## Current AI summary model
+
+`InvoiceSummary` is a structured AI output model, not a persisted RAG document.
+
+| Field | Current meaning |
+|-------|-----------------|
+| `total_invoices`, `total_amount`, `total_iva` | Aggregate values requested from Anthropic. |
+| `date_range` | Summary date range. |
+| `top_vendors` | List of `VendorSummary` items. |
+| `anomalies` | List of `AnomalyFlag` items. |
+| `voided_count` | Count of voided invoices. |
+| `category_suggestions` | Suggested categories derived by the AI prompt. |
+
+The prompt sends a reduced list of invoice fields and caps displayed invoice data
+to the first 100 records. This is batch analysis, not retrieval over a document
+corpus.
+
+## Proposed SaaS and RAG domain concepts
+
+The concepts below are required for the target product direction but are not in
+the current codebase.
+
+| Proposed concept | Proposed responsibility | Current status |
+|------------------|-------------------------|----------------|
+| User | Owns sessions and actions. | **Proposed** — no user model exists. |
+| Tenant or organization | Groups users and scopes data access. | **Proposed** — no tenant key exists on invoice tables. |
+| Membership/role | Defines who can upload, query, administer, or audit tenant data. | **Proposed** — no authorization model exists. |
+| Source document | Represents the original uploaded file and storage metadata. | **Proposed** — current upload stores filename and parsed records, not durable object metadata. |
+| Document chunk | Searchable text segment linked to a source document and tenant. | **Proposed** — no chunk table or chunking service exists. |
+| Embedding | Vector representation of a chunk or invoice fact. | **Proposed** — no embedding service or vector index exists. |
+| Retrieval result | Authorized chunk/fact selected for answer generation. | **Proposed** — no retriever exists. |
+| Citation | Source reference returned with an answer. | **Proposed** — no citation contract exists. |
+| Invoice chat session | Conversation over a tenant-scoped invoice corpus. | **Proposed** — current chat is generic prompt streaming. |
+
+## Proposed relationship sketch
+
+```text
+Tenant 1 ── * UserMembership * ── 1 User
+Tenant 1 ── * UploadBatch 1 ── * Invoice
+Tenant 1 ── * SourceDocument 1 ── * DocumentChunk 1 ── * Embedding
+InvoiceChatSession 1 ── * Message
+Message * ── * Citation -> Invoice or DocumentChunk
+```
+
+This sketch is a planning aid only. A future implementation must choose exact
+table names, indexes, migrations, authorization checks, and deletion semantics.
+
+## Modeling rules for future work
+
+- Tenant/user ownership must be enforced before proposed retrieval or chat.
+- Proposed document and chunk records should link back to upload batches when
+  they originate from invoice uploads.
+- Proposed citations should identify enough source metadata for a user to verify
+  an answer.
+- Proposed RAG models must not replace current structured invoice facts; they
+  should complement them.
+
+## Non-goals for this documentation slice
+
+- No new SQLModel tables or migrations.
+- No auth, tenant, document, chunk, embedding, retrieval, citation, or chat
+  session implementation.
+- No change to current invoice upload validation or persistence behavior.
+
+## Current claim cross-check
+
+The Current model claims in this document were checked against
+`app/models/invoice.py`, `app/models/db_models.py`, `app/schemas/response.py`,
+`app/services/invoice_service.py`, `app/services/invoice_ai_service.py`,
+`app/infrastructure/repositories.py`, and the invoice/repository tests. Missing
+SaaS and RAG concepts remain labeled **Proposed**.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,126 @@
+# Invoice RAG Implementation Plan
+
+This plan turns the proposed SaaS/RAG direction into reviewable future work. The
+current change is documentation-only. It does not implement authentication,
+tenancy, object storage, vector search, invoice chat, or new API behavior.
+
+## Quick path
+
+1. Protect the current upload workflow before adding SaaS boundaries.
+2. Add ownership and authorization before retrieval or chat.
+3. Build RAG in small slices: source documents, chunks, embeddings, retrieval,
+   grounded answers, then evaluation.
+
+## Current starting point
+
+| Capability | Current state |
+|------------|---------------|
+| Invoice upload | Implemented at `POST /invoice/upload`. |
+| Structured persistence | Implemented for upload batches, companies, invoices, and invoice tax details. |
+| AI batch summary | Implemented as optional Anthropic analysis after upload. |
+| Generic chat/agent | Implemented, but not connected to invoice data. |
+| SaaS auth/tenancy | **Proposed** — not implemented. |
+| RAG retrieval/citations | **Proposed** — not implemented. |
+
+## Proposed phased roadmap
+
+### Phase 1: Stabilize current invoice boundaries
+
+Outcome: current upload behavior remains safe to extend.
+
+- Add regression coverage around successful upload, invalid file handling, AI
+  summary failure, and batch persistence if gaps are found.
+- Document and preserve the current `UploadResult` response fields.
+- Avoid changing invoice table semantics before tenant ownership is designed.
+
+### Phase 2: Add SaaS identity and ownership
+
+Outcome: invoice data can be scoped to authenticated users or tenants.
+
+- Choose an authentication mechanism and token/session contract.
+- Add user, tenant/organization, and membership concepts.
+- Add tenant ownership to upload batches and invoice records through migrations.
+- Enforce authorization at API and repository/service boundaries.
+
+### Phase 3: Expose tenant-scoped invoice reads
+
+Outcome: users can safely inspect their invoice corpus without chat.
+
+- Add invoice list/detail endpoints scoped by tenant membership.
+- Support basic filters such as date, vendor NIT/name, invoice type, status, and
+  amount range.
+- Keep aggregate calculations backed by structured invoice facts.
+
+### Phase 4: Add source document storage
+
+Outcome: uploaded files can be cited and reprocessed.
+
+- Define source document metadata linked to upload batches and tenant ownership.
+- Store original files in the selected object storage provider.
+- Track ingestion status and failure reasons separately from upload success.
+
+### Phase 5: Build ingestion for chunks and embeddings
+
+Outcome: invoice documents become retrievable evidence.
+
+- Extract text from source documents where available.
+- Chunk text with invoice-aware metadata.
+- Generate embeddings for chunks and selected structured facts.
+- Store vectors with tenant and authorization metadata.
+
+### Phase 6: Add grounded invoice chat
+
+Outcome: users can ask questions over authorized invoice evidence.
+
+- Add an invoice chat endpoint with tenant-scoped retrieval.
+- Combine structured filters and vector retrieval.
+- Generate answers only from authorized evidence.
+- Return citations and retrieval metadata with each answer.
+
+### Phase 7: Evaluate and operate RAG quality
+
+Outcome: retrieval behavior can be reviewed and improved safely.
+
+- Add test fixtures for answerable, unanswerable, and cross-tenant questions.
+- Track citation coverage, retrieval hit rate, and unsupported-answer declines.
+- Add operational visibility for ingestion and retrieval failures.
+
+## Reviewable work units
+
+| Work unit | Review boundary | Suggested verification |
+|-----------|-----------------|------------------------|
+| Auth foundation | Auth dependency and user identity model only. | Unit/integration tests for authenticated and unauthenticated requests. |
+| Tenant ownership | Migrations and tenant-scoped repositories. | Repository tests proving cross-tenant exclusion. |
+| Invoice reads | Read-only invoice APIs. | API tests for filters and authorization. |
+| Source documents | Metadata and object storage adapter. | Service tests with storage mocked at the boundary. |
+| Chunking | Deterministic chunk creation. | Pure unit tests for chunk boundaries and metadata. |
+| Embeddings/index | Embedding service and vector persistence. | Adapter tests and integration tests against chosen vector store. |
+| Invoice chat | Retrieval, answer generation, and citations. | Integration tests for grounded answers and no-evidence cases. |
+
+## Proposed sequencing rules
+
+- Do not implement invoice chat before authorization and tenant ownership exist.
+- Do not run vector retrieval across unfiltered global data.
+- Keep tests with each behavior slice under Strict TDD.
+- Keep each PR reviewable; split large migrations, API changes, and RAG
+  orchestration into separate stacked work units.
+- Preserve existing upload response compatibility unless a future PR explicitly
+  changes the API contract.
+
+## Open decisions for future implementation
+
+| Decision | Why it matters |
+|----------|----------------|
+| Authentication provider | Determines dependencies, local testing, and token validation. |
+| Tenant model | Controls ownership, collaboration, and authorization semantics. |
+| Object storage provider | Determines source document durability and citation links. |
+| Vector store | Determines retrieval filters, migrations, and local test strategy. |
+| Embedding model | Affects cost, latency, language quality, and reindexing strategy. |
+| Citation UX/API | Determines how users verify answers and report issues. |
+
+## Documentation-only completion criteria
+
+- The seven requested docs exist under `docs/`.
+- Current behavior is supported by inspected source or tests.
+- Proposed SaaS/RAG behavior is labeled **Proposed**.
+- No application code or runtime behavior changes are introduced.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -32,6 +32,7 @@ service, not yet a multi-user RAG SaaS.
 | Invoice document storage | Original uploads are stored durably and linked to parsed records. | **Proposed** — no object storage contract is implemented. |
 | Invoice RAG | Users ask questions over their invoice corpus and receive grounded answers with citations. | **Proposed** — no embeddings, vector index, retriever, or citation pipeline exists. |
 | Conversation history | Invoice Q&A sessions preserve context while respecting tenant boundaries. | **Proposed** — current chat is generic prompt streaming. |
+| Configurable AI providers | Tenants can choose the AI provider used for summaries, chat, and future RAG generation, including using their own paid provider subscription when supported. | **Proposed** — current AI integration is Anthropic-specific. |
 | Admin operations | Operators can inspect ingestion health, retrieval quality, and failed jobs. | **Proposed** — no admin surface is implemented. |
 
 ## Target users
@@ -62,11 +63,20 @@ service, not yet a multi-user RAG SaaS.
 - Proposed answers SHOULD cite source invoices or uploaded documents.
 - Proposed retrieval SHOULD separate parsed structured invoice facts from raw
   document text when both become available.
+- Proposed AI features SHOULD be provider-agnostic so the system can support
+  Anthropic, OpenAI, Google, or another compatible provider without changing
+  invoice-domain behavior.
+- Proposed tenant settings SHOULD allow a user or tenant to select a supported
+  AI provider and, where appropriate, use their own provider subscription or API
+  credentials.
+- Proposed provider switching MUST preserve tenant isolation, auditability, and
+  answer-grounding requirements.
 
 ## Non-goals
 
 - This documentation change does not add authentication, tenancy, migrations,
-  object storage, embeddings, vector search, invoice chat, or RAG retrieval.
+  object storage, embeddings, vector search, invoice chat, RAG retrieval, or
+  multi-provider AI configuration.
 - This documentation change does not alter application code or runtime behavior.
 - Current invoice upload must not be treated as production-grade SaaS isolation.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,80 @@
+# Invoice RAG Product Requirements
+
+This product baseline describes the invoice assistant as it exists today and the
+SaaS-ready RAG direction it should evolve toward. **Current** means the behavior
+is supported by inspected code or tests. **Proposed** means product direction
+only; it is not implemented by this documentation change.
+
+## Product outcome
+
+Help users upload SAT invoice files, preserve the parsed invoice data, and move
+toward trusted invoice Q&A with citations. The near-term product must stay
+honest about the current system: it is an invoice upload and AI batch summary
+service, not yet a multi-user RAG SaaS.
+
+## Current scope
+
+| Capability | Current behavior | Evidence |
+|------------|------------------|----------|
+| Invoice upload | Users can upload SAT Excel files to `POST /invoice/upload` with `invoiceType` set to `expenses` or `incomes`. | `app/api/invoices.py`, `app/models/invoice.py` |
+| SAT row normalization | The service maps Spanish SAT column names to internal field names, validates rows, and rejects invalid or empty files. | `app/services/invoice_service.py`, `tests/test_invoice_service.py` |
+| Persistence | The service stores upload batches, companies, invoices, and invoice tax detail rows. | `app/models/db_models.py`, `app/infrastructure/repositories.py`, `tests/test_repositories.py` |
+| Batch totals | Upload results include row count, total amount, IVA total, status, upload timestamp, and optional AI summary. | `app/services/invoice_service.py`, `tests/test_invoice_upload.py` |
+| AI batch analysis | After upload, the API attempts an Anthropic-backed structured invoice summary over validated rows. If AI analysis fails, upload can still return successfully with no summary. | `app/api/invoices.py`, `app/services/invoice_ai_service.py`, `tests/test_invoice_upload.py` |
+| Generic AI endpoints | The app exposes generic summarization, streaming chat, and agent streaming endpoints. These flows do not retrieve invoice records today. | `app/api/routes.py`, `app/api/chat.py`, `app/api/agent.py` |
+
+## Proposed SaaS and RAG scope
+
+| Capability | Proposed behavior | Current status |
+|------------|-------------------|----------------|
+| Authentication | Users sign in and every invoice action is scoped to the authenticated user or tenant. | **Proposed** — no auth boundary is implemented. |
+| Tenant isolation | Data access is filtered by tenant and enforced before retrieval, summarization, or chat. | **Proposed** — current invoice records are not tenant-scoped. |
+| Invoice document storage | Original uploads are stored durably and linked to parsed records. | **Proposed** — no object storage contract is implemented. |
+| Invoice RAG | Users ask questions over their invoice corpus and receive grounded answers with citations. | **Proposed** — no embeddings, vector index, retriever, or citation pipeline exists. |
+| Conversation history | Invoice Q&A sessions preserve context while respecting tenant boundaries. | **Proposed** — current chat is generic prompt streaming. |
+| Admin operations | Operators can inspect ingestion health, retrieval quality, and failed jobs. | **Proposed** — no admin surface is implemented. |
+
+## Target users
+
+| User | Job to be done |
+|------|----------------|
+| Business owner | Upload SAT invoice files and understand spending or income patterns. |
+| Accountant | Review invoice totals, voided invoices, vendor concentration, and anomalies. |
+| SaaS tenant admin | **Proposed**: manage team access and data boundaries. |
+| Future coding agent | Use this documentation to extend the system without overclaiming missing behavior. |
+
+## Requirements
+
+### Current requirements
+
+- The system MUST continue accepting supported SAT invoice spreadsheets through
+  `POST /invoice/upload`.
+- The upload response MUST preserve existing totals and status fields.
+- AI summary failure MUST NOT turn an otherwise valid upload into a failed
+  upload.
+- Generic AI endpoints MUST NOT be described as invoice RAG endpoints.
+
+### Proposed requirements
+
+- The future SaaS system SHOULD require authentication before invoice upload,
+  invoice retrieval, or invoice chat.
+- Tenant and user ownership checks MUST happen before any proposed RAG retrieval.
+- Proposed answers SHOULD cite source invoices or uploaded documents.
+- Proposed retrieval SHOULD separate parsed structured invoice facts from raw
+  document text when both become available.
+
+## Non-goals
+
+- This documentation change does not add authentication, tenancy, migrations,
+  object storage, embeddings, vector search, invoice chat, or RAG retrieval.
+- This documentation change does not alter application code or runtime behavior.
+- Current invoice upload must not be treated as production-grade SaaS isolation.
+
+## Success criteria for the documentation baseline
+
+- Readers can identify which capabilities are **Current** and which are
+  **Proposed**.
+- The canonical PRD source is this `docs/PRD.md` file; the old lowercase
+  `docs/prd.md` file no longer remains as a competing PRD source.
+- Future implementation work can be split into reviewable slices without
+  confusing proposed RAG behavior with current upload behavior.

--- a/docs/RAG_STRATEGY.md
+++ b/docs/RAG_STRATEGY.md
@@ -1,0 +1,105 @@
+# Invoice RAG Strategy
+
+This strategy defines the proposed retrieval approach for invoice Q&A. The
+current application uploads SAT invoice spreadsheets, persists structured invoice
+records, and can request an AI batch summary. It does not implement embeddings,
+vector search, tenant-scoped retrieval, citations, or invoice chat today.
+
+## Quick path
+
+1. Treat every RAG component in this document as **Proposed**.
+2. Keep retrieval authorization before search, not after answer generation.
+3. Use citations to make answers verifiable against invoice facts or source
+   documents.
+
+## Current baseline
+
+| Area | Current behavior | Evidence |
+|------|------------------|----------|
+| Structured invoice facts | SAT spreadsheet rows are normalized, validated, and stored as upload batches, companies, invoices, and tax details. | `app/services/invoice_service.py`, `app/models/db_models.py` |
+| AI analysis | The upload route optionally sends validated rows to Anthropic for a structured batch summary. | `app/api/invoices.py`, `app/services/invoice_ai_service.py` |
+| Generic chat | `/chat/stream` streams a raw prompt through Anthropic and does not retrieve invoice records. | `app/api/chat.py`, `app/services/ll_stream_service.py` |
+| Agent tools | The agent loop exists, but the registered tool surface is not invoice-specific. | `app/api/agent.py`, `app/agents/tools.py` |
+
+## Proposed retrieval goals
+
+| Goal | Proposed behavior |
+|------|-------------------|
+| Tenant-safe answers | Retrieve only records and chunks the authenticated user is allowed to access. |
+| Grounded responses | Generate answers from retrieved invoice facts and document chunks, not from the prompt alone. |
+| Verifiable citations | Return references to invoice IDs, upload batches, document chunks, or source locations used by the answer. |
+| Structured + unstructured search | Combine relational invoice filters with semantic document retrieval when both exist. |
+| Evaluation loop | Track whether retrieved evidence supports the final answer. |
+
+## Proposed ingestion pipeline
+
+```text
+Authenticated upload
+  -> persist current structured invoice facts
+  -> store original source document metadata
+  -> extract normalized text from source document
+  -> chunk text using deterministic rules
+  -> create embeddings for chunks and selected structured facts
+  -> index embeddings with tenant and authorization metadata
+```
+
+### Proposed chunking rules
+
+- Chunk by invoice boundaries when the source format supports it.
+- Keep invoice identifiers, dates, vendor NIT/name, totals, IVA, and upload batch
+  metadata with every chunk.
+- Prefer smaller chunks that preserve one invoice or a coherent group of invoice
+  lines over large pages with unrelated vendors.
+- Store a stable `source_document_id`, chunk ordinal, and source locator for
+  citations.
+
+## Proposed retrieval flow
+
+```text
+Invoice question
+  -> authenticate user
+  -> resolve tenant and authorization scope
+  -> classify intent: aggregate, lookup, anomaly, or narrative question
+  -> query structured invoice facts when filters are explicit
+  -> query vector index for semantic context when narrative evidence is needed
+  -> rank and deduplicate evidence
+  -> generate answer with citations
+  -> return answer, citations, and retrieval metadata
+```
+
+## Proposed authorization constraints
+
+Authorization is a retrieval precondition. A future implementation should:
+
+- Filter every structured invoice query by tenant/user ownership.
+- Filter every vector query by tenant and document access metadata.
+- Never retrieve globally and then remove unauthorized results afterward.
+- Include authorization tests before exposing invoice chat endpoints.
+
+## Proposed citation contract
+
+Each cited source should include enough metadata for review:
+
+| Citation field | Proposed meaning |
+|----------------|------------------|
+| `source_type` | `invoice`, `upload_batch`, or `document_chunk`. |
+| `source_id` | Stable identifier for the cited record. |
+| `label` | Human-readable invoice number, vendor, date, or document name. |
+| `excerpt` | Short evidence text used by the answer. |
+| `confidence` | Retrieval or grounding confidence when available. |
+
+## Proposed evaluation checks
+
+- Retrieval returns at least one authorized citation for answerable invoice
+  questions.
+- Answers decline when no authorized evidence is found.
+- Aggregate answers match structured invoice totals for the selected scope.
+- Citation excerpts support the exact claim made in the answer.
+- Cross-tenant data never appears in retrieved evidence or citations.
+
+## Non-goals for this documentation change
+
+- No embedding model, vector database, retriever, ingestion job, or citation API
+  is implemented here.
+- No claim is made that current generic chat can answer invoice questions from
+  persisted invoice data.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,49 @@
+# Invoice RAG Documentation
+
+This folder is the documentation entry point for the invoice assistant. The
+current application supports SAT invoice upload, persistence, and optional AI
+batch summaries. SaaS tenancy, authentication, invoice chat, vector search, and
+RAG are **Proposed** product direction unless a later implementation adds them.
+
+## Quick path
+
+1. Start with [`PRD.md`](./PRD.md) for product scope and non-goals.
+2. Use the technical docs below when reviewing or planning future work.
+3. Check whether a section says **Current** or **Proposed** before treating it
+   as implemented behavior.
+
+## Documentation map
+
+| Document | Status in this stacked change | Reader job |
+|----------|-------------------------------|------------|
+| [`PRD.md`](./PRD.md) | Current slice | Understand product direction, current scope, proposed scope, and non-goals. |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | Current slice | Review current FastAPI layers and proposed SaaS/RAG evolution. |
+| [`DOMAIN_MODEL.md`](./DOMAIN_MODEL.md) | Current slice | Review current invoice entities and proposed document/RAG concepts. |
+| [`RAG_STRATEGY.md`](./RAG_STRATEGY.md) | Current slice | Plan proposed retrieval, chunking, embeddings, grounding, and citations. |
+| [`API_DESIGN.md`](./API_DESIGN.md) | Current slice | Compare current endpoints with proposed invoice query/chat APIs. |
+| [`IMPLEMENTATION_PLAN.md`](./IMPLEMENTATION_PLAN.md) | Current slice | Follow the reviewable implementation roadmap. |
+
+## Current implementation summary
+
+| Area | Current behavior | Source |
+|------|------------------|--------|
+| Health | `GET /health` returns `{"status": "ok"}`. | `app/api/routes.py` |
+| Invoice upload | `POST /invoice/upload` accepts an uploaded SAT spreadsheet and `invoiceType`. | `app/api/invoices.py` |
+| Invoice parsing | Excel files are parsed with pandas, SAT columns are renamed, and rows are validated with Pydantic. | `app/services/invoice_service.py`, `app/models/invoice.py` |
+| Persistence | Upload batches, companies, invoices, and invoice tax details are persisted through SQLModel repositories. | `app/models/db_models.py`, `app/infrastructure/repositories.py` |
+| AI summary | Uploads attempt an Anthropic-backed batch analysis; failures are logged and the upload result can still succeed without `ai_summary`. | `app/api/invoices.py`, `app/services/invoice_ai_service.py`, `tests/test_invoice_upload.py` |
+| Generic AI | `/summarize`, `/chat/stream`, and `/agent/stream` are generic Anthropic flows, not invoice RAG flows. | `app/api/routes.py`, `app/api/chat.py`, `app/api/agent.py` |
+
+## Proposed direction summary
+
+The target product direction is a multi-user SaaS invoice assistant with secure
+document ownership, tenant-aware retrieval, grounded answers, citations, and a
+reviewable API surface for invoice Q&A. These capabilities are **Proposed** and
+are not implemented by this documentation change.
+
+## Non-goals for this documentation change
+
+- No runtime upload, chat, authentication, tenancy, vector search, or RAG
+  behavior changes.
+- No database migrations, object storage, embeddings, or frontend changes.
+- No new endpoints or placeholder implementation code.

--- a/openspec/changes/archive/2026-06-10-invoice-rag-documentation/archive-report.md
+++ b/openspec/changes/archive/2026-06-10-invoice-rag-documentation/archive-report.md
@@ -1,0 +1,52 @@
+# Archive Report: Invoice RAG Product and Technical Documentation
+
+**Change**: `invoice-rag-documentation`  
+**Archived on**: 2026-06-10  
+**Artifact store**: OpenSpec  
+**Verdict**: Archived with warnings
+
+## Gate Validation
+
+- Task completion gate: PASSED. `tasks.md` contains 14 checked tasks and no unchecked implementation tasks.
+- Verification gate: PASSED WITH WARNINGS. `verify-report.md` reports `CRITICAL: None` and verdict `PASS WITH WARNINGS`.
+- Archive policy: No destructive delta merge was required because no main spec existed for this domain.
+
+## Spec Sync
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| `invoice-rag-documentation` | Created | Copied the change spec into `openspec/specs/invoice-rag-documentation/spec.md` as the new main source of truth. |
+
+## Archive Verification
+
+- Main spec updated: PASSED. `openspec/specs/invoice-rag-documentation/spec.md` exists and contains the archived capability requirements.
+- Change folder moved: PASSED. The active change folder was moved to `openspec/changes/archive/2026-06-10-invoice-rag-documentation/`.
+- Active change removal: PASSED. `openspec/changes/invoice-rag-documentation/` is absent.
+- Archived tasks state: PASSED. Archived `tasks.md` has no unchecked implementation tasks.
+- Verification severity: PASSED. Archived `verify-report.md` has no CRITICAL issues.
+
+## Archive Contents
+
+- `proposal.md`
+- `exploration.md`
+- `design.md`
+- `tasks.md`
+- `verify-report.md`
+- `archive-report.md`
+- `specs/invoice-rag-documentation/spec.md`
+
+## Warnings Carried Forward
+
+- Runtime verification was skipped because `ANTHROPIC_API_KEY` and `DATABASE_URL` were missing.
+- Strict TDD runtime compliance is limited for this documentation-only change; verification used static documentation and repository inspection evidence.
+- Documentation/OpenSpec artifacts were untracked before archive, so reviewers must inspect untracked files as well as normal diffs.
+
+## Source of Truth
+
+The main specification is now:
+
+- `openspec/specs/invoice-rag-documentation/spec.md`
+
+The active change folder was moved to:
+
+- `openspec/changes/archive/2026-06-10-invoice-rag-documentation/`

--- a/openspec/changes/archive/2026-06-10-invoice-rag-documentation/design.md
+++ b/openspec/changes/archive/2026-06-10-invoice-rag-documentation/design.md
@@ -1,0 +1,91 @@
+# Design: Invoice RAG Product and Technical Documentation
+
+## Technical Approach
+
+Create a documentation-only baseline under `docs/` that is grounded in the
+inspected FastAPI code and optimized for future reviewers and AI coding agents.
+The docs will describe Current behavior first, then mark SaaS tenancy,
+authentication, invoice chat, embeddings, vector search, object storage, and RAG
+retrieval as **Proposed**. No application files, database schema, endpoints, or
+runtime behavior will be changed by this change.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives considered | Rationale |
+|----------|--------|--------------------------|-----------|
+| Current vs Proposed labeling | Each substantive section uses explicit **Current** and **Proposed** labels. | Product-only narrative; architecture-only slice. | Prevents overclaiming missing SaaS/RAG behavior while still preserving product direction. |
+| Canonical PRD path | Replace/rename lowercase `docs/prd.md` with canonical `docs/PRD.md`; do not keep both. | Keep both files; leave lowercase stub. | Avoids ambiguity and case-sensitivity problems across filesystems. |
+| Documentation structure | Use `docs/README.md` as a navigation hub and keep each doc focused on one reader job. | One large design document. | Reduces cognitive load and satisfies the requested documentation set. |
+| Runtime boundary | Application code remains reference-only. | Add placeholder APIs/models for proposed RAG. | The spec requires documentation only; placeholders would create misleading implementation claims. |
+
+## Data Flow
+
+Current invoice upload flow to document:
+
+```text
+POST /invoice/upload
+  -> app/api/invoices.py reads UploadFile + invoiceType
+  -> InvoiceService parses Excel with pandas, renames SAT columns, validates rows
+  -> repositories persist UploadBatch, Company, Invoice, InvoiceTaxDetail
+  -> InvoiceAIService optionally summarizes validated rows through Anthropic
+  -> UploadResult returns batch totals and optional ai_summary
+```
+
+Current generic AI flows to document separately:
+
+```text
+/summarize -> LLMService -> Anthropic messages API
+/chat/stream -> LLMStreamService -> streaming Anthropic response
+/agent/stream -> ClaudeAgentLoop -> tool registry loop
+```
+
+These flows do not retrieve invoice data today, so invoice chat/RAG data flow is
+Proposed only.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docs/README.md` | Create | Navigation hub for product, architecture, domain, RAG, API, and plan docs. |
+| `docs/PRD.md` | Create/Rename | Canonical product document replacing `docs/prd.md`; covers SaaS-ready direction and Current vs Proposed scope. |
+| `docs/prd.md` | Delete/Rename | Remove lowercase stub to avoid conflicting PRD sources. |
+| `docs/ARCHITECTURE.md` | Create | Current layered FastAPI architecture plus Proposed SaaS/RAG evolution. |
+| `docs/DOMAIN_MODEL.md` | Create | Current SQLModel/Pydantic invoice entities plus Proposed user/document/chunk concepts. |
+| `docs/RAG_STRATEGY.md` | Create | Proposed retrieval, chunking, embedding, grounding, citations, and authorization constraints. |
+| `docs/API_DESIGN.md` | Create | Current endpoints and Proposed invoice query/chat API direction. |
+| `docs/IMPLEMENTATION_PLAN.md` | Create | Phased, reviewable implementation path for future work. |
+| `README.md` | Optional Modify | Add a short pointer to `docs/README.md` only if task budget allows. |
+
+## Interfaces / Contracts
+
+No runtime interfaces are added or changed. Documentation contracts:
+
+- Any Current claim about upload, persistence, AI summaries, streaming, or tests
+  MUST cite or clearly map to inspected files such as `app/api/invoices.py`,
+  `app/services/invoice_service.py`, `app/services/invoice_ai_service.py`,
+  `app/models/db_models.py`, and `tests/`.
+- Any mention of auth, users, tenant isolation, vector search, embeddings,
+  object storage, migrations, invoice chat, or RAG retrieval MUST be labeled
+  **Proposed** unless implemented before these docs are written.
+- `docs/PRD.md` is the only PRD source after this change.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Static review | Required docs exist and `docs/prd.md` conflict is gone. | Inspect `docs/` and git diff. |
+| Content review | Current claims match code; Proposed claims are labeled. | Cross-check docs against inspected app/test files. |
+| Runtime regression | App behavior remains unchanged. | No app-code tests required; optionally run `PYTHONPATH=. uv run pytest` if environment variables and dependencies are available. |
+
+## Migration / Rollout
+
+No runtime migration required. Rollout is a documentation-only commit. The only
+file migration is `docs/prd.md` to `docs/PRD.md`; use a git-aware rename when
+possible and verify only one PRD remains.
+
+## Open Questions
+
+- [ ] Should `README.md` link to `docs/README.md` in this change, or should the
+  seven requested docs remain the only documentation surface?
+- [ ] Should task planning split the seven-doc set to protect the 400-line
+  review budget, or keep a concise single documentation PR?

--- a/openspec/changes/archive/2026-06-10-invoice-rag-documentation/exploration.md
+++ b/openspec/changes/archive/2026-06-10-invoice-rag-documentation/exploration.md
@@ -1,0 +1,62 @@
+## Exploration: Invoice RAG Documentation
+
+### Current State
+- The application is a Python 3.12 FastAPI service with a layered structure: API routers in `app/api/`, business services in `app/services/`, infrastructure in `app/infrastructure/`, Pydantic/SQLModel models in `app/models/`, and shared config/logging in `app/core/`.
+- Current invoice upload functionality exists at `POST /invoice/upload` in `app/api/invoices.py`. It accepts an uploaded Excel file plus `invoiceType`, reads the file in `InvoiceService`, validates SAT-style invoice rows with `InvoiceRowSchema`, persists batches, companies, invoices, and tax details, then optionally adds an AI-generated batch summary.
+- Current invoice persistence exists through SQLModel tables in `app/models/db_models.py`: `UploadBatch`, `Company`, `Invoice`, and `InvoiceTaxDetail`. Repository methods in `app/infrastructure/repositories.py` support basic create/update flows, but not invoice search, filtering, user ownership, document chunks, embeddings, or chat retrieval.
+- Current AI functionality exists in three separate forms: `/summarize` via `LLMService`, `/chat/stream` via `LLMStreamService`, and `/agent/stream` via `ClaudeAgentLoop`. These chat/agent endpoints currently use only the raw prompt and do not retrieve invoice data from the database.
+- Current invoice AI analysis exists in `InvoiceAIService.analyze_batch`, which sends up to the first 100 validated invoice rows to Anthropic through Instructor and returns a structured `InvoiceSummary`. This is batch summarization, not RAG.
+- Current database setup uses async SQLAlchemy/SQLModel in `app/infrastructure/database.py`, initializes schema with `SQLModel.metadata.create_all`, and depends on `DATABASE_URL`. There is no migration layer visible in the inspected code.
+- Current tests cover health, invoice upload, invoice row validation, invoice service processing, and repositories. Tests use an in-memory SQLite async engine and dependency overrides.
+- Existing documentation is minimal: root `README.md` is a setup stub and `docs/prd.md` contains only headings. The requested documentation set is therefore mostly new or replacement documentation.
+- No React frontend, vector database, embeddings, RAG retrieval pipeline, file object storage, user/account model, authentication, invoice query API, or chat-over-invoices endpoint was found in the inspected code. These must be documented as **Proposed**, not current implementation.
+
+### Affected Areas
+- `docs/README.md` — Proposed top-level documentation entry point for future AI coding agents and contributors.
+- `docs/PRD.md` — Proposed product requirements document; current `docs/prd.md` exists but is lowercase and only a stub, so naming/cleanup should be decided in the proposal.
+- `docs/ARCHITECTURE.md` — Proposed architecture documentation covering current FastAPI layers and proposed invoice-chat/RAG evolution.
+- `docs/DOMAIN_MODEL.md` — Proposed domain model documentation for current persisted entities and proposed RAG/document concepts.
+- `docs/RAG_STRATEGY.md` — Proposed strategy for invoice metadata retrieval, document chunking, embeddings, vector search, and grounded answers.
+- `docs/API_DESIGN.md` — Proposed API contract documentation for existing endpoints plus proposed invoice listing/query/chat/RAG endpoints.
+- `docs/IMPLEMENTATION_PLAN.md` — Proposed phased implementation plan designed for future AI coding agents and reviewable work units.
+- `README.md` — Existing project README may need to point to `docs/README.md` later, but should not be changed during exploration.
+- `app/api/invoices.py` — Current invoice upload endpoint that docs must describe accurately.
+- `app/services/invoice_service.py` — Current Excel parsing, row validation, chunk processing, persistence, and upload result assembly.
+- `app/services/invoice_ai_service.py` — Current batch analysis behavior that should be distinguished from future RAG.
+- `app/models/invoice.py` — Current invoice row and AI summary DTOs.
+- `app/models/db_models.py` — Current persisted invoice schema and relationship source of truth.
+- `app/infrastructure/repositories.py` — Current persistence capabilities and missing query/retrieval methods.
+- `app/api/chat.py`, `app/api/agent.py`, `app/agents/` — Current generic chat/agent streaming functionality; not invoice-aware today.
+- `tests/` — Current behavior evidence for docs; no docs implementation tests are required unless future phases choose markdown/content checks.
+
+### Approaches
+1. **Current-vs-Proposed documentation baseline** — Create practical docs that separate implemented behavior from proposed architecture using explicit labels.
+   - Pros: Prevents invented implementation details; gives future agents a trustworthy baseline; directly supports clean RAG planning.
+   - Cons: Requires careful wording to avoid overpromising future React/vector database/database migration pieces.
+   - Effort: Medium
+
+2. **Aspirational product-first documentation** — Write the full future product story first, with current implementation details only as background.
+   - Pros: Strong product narrative; useful for stakeholder alignment.
+   - Cons: Higher risk of confusing proposed capabilities with existing code; less useful for AI coding agents that need exact implementation boundaries.
+   - Effort: Medium
+
+3. **Architecture-only documentation slice** — Start with `ARCHITECTURE.md`, `DOMAIN_MODEL.md`, and `RAG_STRATEGY.md`, leaving PRD/API/implementation docs for later.
+   - Pros: Smaller review surface; focuses on technical foundation.
+   - Cons: Does not satisfy the full requested documentation set; weaker product/API alignment.
+   - Effort: Low
+
+### Recommendation
+Use the **Current-vs-Proposed documentation baseline** approach for the later docs-only implementation. Each document should lead with what exists today, mark missing/future capabilities as **Proposed**, and avoid presenting PostgreSQL, React, vector database, embeddings, RAG, authentication, or invoice chat retrieval as implemented unless future code adds them first.
+
+For cognitive load, structure the eventual docs as a connected set: `docs/README.md` as the navigation hub, `PRD.md` for product intent, `ARCHITECTURE.md` for system shape, `DOMAIN_MODEL.md` for entities, `RAG_STRATEGY.md` for retrieval design, `API_DESIGN.md` for current/proposed API contracts, and `IMPLEMENTATION_PLAN.md` for phased execution.
+
+### Risks
+- Existing `docs/prd.md` uses lowercase while the requested artifact is `docs/PRD.md`; case-sensitive and case-insensitive filesystems may behave differently, so the proposal should explicitly handle rename/update strategy.
+- Current database schema is created directly through SQLModel metadata with no visible migration system; docs should not imply migration maturity.
+- Current chat and agent endpoints are generic and not invoice-aware; calling them invoice chat or RAG without a **Proposed** label would misrepresent the implementation.
+- `InvoiceAIService` analyzes only up to the first 100 validated rows in prompt context; this is not reliable retrieval and should be documented as current batch summarization only.
+- Future RAG design needs decisions that are not in code yet: user/account boundaries, file storage retention, embedding model, vector store, retrieval filters, authorization, citation format, and metadata indexing.
+- Documentation-only implementation may exceed the 400-line review budget if all seven requested docs are detailed; future task planning should consider review slices or concise first-pass docs.
+
+### Ready for Proposal
+Yes. The proposal should define a docs-only change that creates or updates the requested documentation artifacts, explicitly distinguishes **Current** from **Proposed**, addresses the `docs/prd.md` vs `docs/PRD.md` naming issue, and keeps the first documentation pass concise enough for review.

--- a/openspec/changes/archive/2026-06-10-invoice-rag-documentation/proposal.md
+++ b/openspec/changes/archive/2026-06-10-invoice-rag-documentation/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: Invoice RAG Product and Technical Documentation
+
+## Intent
+
+Create a trustworthy documentation baseline for a multi-user SaaS-ready invoice assistant. The docs must explain current FastAPI invoice upload, persistence, and AI summarization behavior, while clearly marking invoice chat, tenancy, security boundaries, and RAG capabilities as **Proposed** when they are not implemented.
+
+## Scope
+
+### In Scope
+- Create/update `docs/README.md`, `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/DOMAIN_MODEL.md`, `docs/RAG_STRATEGY.md`, `docs/API_DESIGN.md`, and `docs/IMPLEMENTATION_PLAN.md`.
+- Inspect current code before documenting implementation details.
+- Use clear Markdown, concrete examples, and Current vs Proposed labels for future AI coding agents.
+- Resolve the existing lowercase `docs/prd.md` naming risk by replacing or renaming it to requested `docs/PRD.md` without keeping conflicting PRD files.
+
+### Out of Scope
+- Runtime upload, chat, authentication, tenancy, vector search, or RAG implementation changes.
+- Database migrations, frontend work, object storage, embeddings, or new API behavior.
+
+## Capabilities
+
+### New Capabilities
+- `invoice-rag-documentation`: Defines requirements for the documentation set covering current invoice ingestion, proposed SaaS tenancy/security model, proposed invoice chat/RAG evolution, API direction, and implementation planning.
+
+### Modified Capabilities
+- None. No existing `openspec/specs/` capabilities were found.
+
+## Approach
+
+Use the exploration recommendation: a Current-vs-Proposed documentation baseline. Each doc should lead with implemented facts from code, then separate proposed SaaS/RAG direction. Keep docs reviewable and agent-friendly with summaries, tables, examples, and explicit non-goals.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `docs/` | New/Modified | Add the requested documentation set and handle `prd.md` -> `PRD.md`. |
+| `app/api/`, `app/services/`, `app/models/`, `app/infrastructure/` | Reference only | Source material for accurate Current-state documentation. |
+| `README.md` | Possible Modified | Optional link to `docs/README.md`; no behavior change. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Docs imply proposed SaaS/RAG features already exist | Med | Require explicit Current/Proposed labels. |
+| `docs/prd.md` vs `docs/PRD.md` causes case conflicts | Med | Produce one canonical `docs/PRD.md` and remove/replace the lowercase stub. |
+| Seven docs exceed review budget | Med | Keep first pass concise and consider task slicing later. |
+
+## Rollback Plan
+
+Revert the documentation commit: remove newly added docs, restore `docs/prd.md` if renamed, and leave application code untouched.
+
+## Dependencies
+
+- Existing codebase inspection and `openspec/changes/invoice-rag-documentation/exploration.md`.
+- User direction that the product is multi-user SaaS-ready and this change is documentation-only.
+
+## Success Criteria
+
+- [ ] Requested docs exist under `docs/` with canonical `docs/PRD.md` naming.
+- [ ] Current implementation details are accurate and not invented.
+- [ ] Proposed SaaS, tenancy, security, API, and RAG pieces are labeled as **Proposed**.
+- [ ] No application behavior changes are introduced.

--- a/openspec/changes/archive/2026-06-10-invoice-rag-documentation/specs/invoice-rag-documentation/spec.md
+++ b/openspec/changes/archive/2026-06-10-invoice-rag-documentation/specs/invoice-rag-documentation/spec.md
@@ -1,0 +1,97 @@
+# Invoice RAG Documentation Specification
+
+## Purpose
+
+This capability defines a documentation-only baseline for the invoice assistant.
+The documentation MUST describe implemented invoice ingestion and AI summary
+behavior accurately, while marking SaaS, tenancy, invoice chat, and RAG
+capabilities as Proposed when they are not implemented.
+
+## Requirements
+
+### Requirement: Documentation Set
+
+The change MUST create the requested documentation set under `docs/` and MUST
+avoid application runtime behavior changes.
+
+| Document | Required focus |
+|----------|----------------|
+| `docs/README.md` | Navigation hub for the documentation set. |
+| `docs/PRD.md` | Product direction and Current vs Proposed scope. |
+| `docs/ARCHITECTURE.md` | Current FastAPI architecture and proposed SaaS/RAG evolution. |
+| `docs/DOMAIN_MODEL.md` | Current invoice entities and proposed document/RAG concepts. |
+| `docs/RAG_STRATEGY.md` | Proposed retrieval, chunking, embeddings, grounding, and citations. |
+| `docs/API_DESIGN.md` | Current endpoints and proposed API direction. |
+| `docs/IMPLEMENTATION_PLAN.md` | Phased, reviewable implementation path. |
+
+#### Scenario: Documentation artifacts are present
+
+- GIVEN the documentation change is applied
+- WHEN a reviewer inspects `docs/`
+- THEN each required document MUST exist with the required focus
+- AND no app code change SHALL be required by this capability
+
+#### Scenario: Lowercase PRD conflict is resolved
+
+- GIVEN `docs/prd.md` exists before the change
+- WHEN the documentation set is created
+- THEN the canonical PRD MUST be `docs/PRD.md`
+- AND conflicting lowercase PRD content MUST NOT remain as a separate source
+
+### Requirement: Current vs Proposed Labeling
+
+The documentation MUST distinguish Current implementation from Proposed product
+direction and MUST NOT present missing SaaS/RAG capabilities as existing.
+
+#### Scenario: Current behavior is documented from code
+
+- GIVEN docs describe invoice upload, persistence, or batch AI analysis
+- WHEN the behavior is labeled Current
+- THEN the description MUST be supported by inspected code or tests
+- AND unsupported assumptions MUST NOT be stated as facts
+
+#### Scenario: Future behavior is explicitly marked
+
+- GIVEN docs mention authentication, tenancy, invoice chat, vector search,
+  embeddings, object storage, migrations, or RAG retrieval
+- WHEN those capabilities are not present in the codebase
+- THEN the docs MUST label them as Proposed
+- AND readers MUST be able to tell they are not implemented today
+
+### Requirement: SaaS-Ready Product Direction
+
+The documentation SHOULD frame future product decisions for a multi-user SaaS
+invoice assistant without requiring those features in this change.
+
+#### Scenario: Product docs communicate SaaS direction
+
+- GIVEN a future agent reads the PRD or implementation plan
+- WHEN they look for product direction
+- THEN the docs SHOULD identify multi-user SaaS readiness as the target
+- AND SHOULD separate future tenant/security work from current behavior
+
+#### Scenario: Security boundaries are not overclaimed
+
+- GIVEN docs describe user ownership, authorization, or tenant isolation
+- WHEN those mechanisms are not implemented
+- THEN the docs MUST present them as Proposed boundaries
+- AND MUST NOT imply current production-grade isolation
+
+### Requirement: Reviewable Agent-Friendly Structure
+
+The documentation MUST reduce cognitive load for human reviewers and future AI
+coding agents through concise structure, summaries, tables, and explicit
+non-goals.
+
+#### Scenario: Reader can find the next document
+
+- GIVEN a reader starts at `docs/README.md`
+- WHEN they need product, architecture, domain, RAG, API, or plan details
+- THEN the README MUST route them to the relevant document
+
+#### Scenario: Out-of-scope behavior is clear
+
+- GIVEN a reviewer checks the documentation change
+- WHEN they look for implementation impact
+- THEN the docs MUST state that runtime upload, chat, authentication, tenancy,
+  vector search, and RAG behavior are out of scope for this change

--- a/openspec/changes/archive/2026-06-10-invoice-rag-documentation/tasks.md
+++ b/openspec/changes/archive/2026-06-10-invoice-rag-documentation/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Invoice RAG Product and Technical Documentation
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 500-900 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 product/navigation -> PR 2 technical current-state docs -> PR 3 proposed RAG/API/plan docs |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | stacked-to-develop |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-develop
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Canonical PRD and docs hub | PR 1 | Rename/delete `docs/prd.md`; create `docs/PRD.md` and `docs/README.md`. |
+| 2 | Current technical baseline | PR 2 | Create `docs/ARCHITECTURE.md` and `docs/DOMAIN_MODEL.md`; verify claims against code/tests. |
+| 3 | Proposed RAG/API roadmap | PR 3 | Create `docs/RAG_STRATEGY.md`, `docs/API_DESIGN.md`, `docs/IMPLEMENTATION_PLAN.md`; label proposed behavior. |
+
+## Phase 1: Source Review and Naming Baseline
+
+- [x] 1.1 Inspect `app/api/`, `app/services/`, `app/models/`, `app/infrastructure/`, and `tests/` for Current invoice, AI, streaming, and persistence behavior to document.
+- [x] 1.2 Inspect `docs/prd.md`; plan a git-aware rename or replacement so only canonical `docs/PRD.md` remains.
+
+## Phase 2: Product and Navigation Docs
+
+- [x] 2.1 Create `docs/README.md` as a navigation hub routing readers to product, architecture, domain, RAG, API, and plan docs.
+- [x] 2.2 Create canonical `docs/PRD.md` from `docs/prd.md` as needed, covering SaaS-ready product direction, Current scope, Proposed scope, and non-goals.
+- [x] 2.3 Verify `docs/prd.md` no longer remains as a conflicting separate PRD source.
+
+## Phase 3: Current Technical Baseline Docs
+
+- [x] 3.1 Create `docs/ARCHITECTURE.md` with Current FastAPI layers, invoice upload flow, generic AI flows, and Proposed SaaS/RAG evolution.
+- [x] 3.2 Create `docs/DOMAIN_MODEL.md` with Current invoice database/domain entities and Proposed user, document, chunk, embedding, and citation concepts.
+- [x] 3.3 Cross-check every Current claim in these docs against inspected code or tests.
+
+## Phase 4: Proposed RAG, API, and Plan Docs
+
+- [x] 4.1 Create `docs/RAG_STRATEGY.md` covering Proposed chunking, embeddings, retrieval, grounding, citations, authorization constraints, and evaluation.
+- [x] 4.2 Create `docs/API_DESIGN.md` with Current endpoints and Proposed invoice query/chat API direction without adding runtime behavior.
+- [x] 4.3 Create `docs/IMPLEMENTATION_PLAN.md` with phased, reviewable future work and explicit separation from this documentation-only change.
+
+## Phase 5: Verification
+
+- [x] 5.1 Verify all seven required docs exist under `docs/` and no app code was modified.
+- [x] 5.2 Verify all auth, tenancy, object storage, vector search, embeddings, invoice chat, and RAG references are labeled **Proposed** unless code proves otherwise.
+- [x] 5.3 Optionally run `PYTHONPATH=. uv run pytest` only if env vars and dependencies are available; record if skipped because this is documentation-only.

--- a/openspec/changes/archive/2026-06-10-invoice-rag-documentation/verify-report.md
+++ b/openspec/changes/archive/2026-06-10-invoice-rag-documentation/verify-report.md
@@ -1,0 +1,149 @@
+## Verification Report
+
+**Change**: invoice-rag-documentation  
+**Version**: N/A  
+**Mode**: Strict TDD — documentation-only verification with runtime limitations recorded
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 14 |
+| Tasks complete | 14 |
+| Tasks incomplete | 0 |
+| Required docs | 7/7 present |
+| Lowercase PRD conflict | Resolved: `docs/prd.md` absent |
+
+### Build & Tests Execution
+
+**Build**: ➖ Skipped
+
+```text
+Configured build command: uv run mypy app
+Result: skipped for this documentation-only verification.
+Environment/tool check: mypy module is not available in the uv environment.
+Changed files are Markdown/OpenSpec artifacts only; no Python application code was modified.
+```
+
+**Tests**: ⚠️ Skipped with rationale
+
+```text
+Configured strict TDD test command: PYTHONPATH=. uv run pytest
+Result: not executed because required full-suite environment variables are missing.
+Environment check:
+- ANTHROPIC_API_KEY=missing
+- DATABASE_URL=missing
+- pytest=available
+- pytest-cov=available
+
+This change is documentation-only, so no new or modified production/test code provides
+a meaningful narrower runtime test target. No passing runtime behavior evidence is claimed.
+```
+
+**Coverage**: ➖ Not generated — pytest-cov is available, but test execution was skipped because required environment variables are missing.
+
+### TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ⚠️ | Apply progress contains per-task `TDD Applicability Evidence`, not a classic RED/GREEN cycle table, because the change is documentation-only. |
+| All tasks have tests | ➖ | No production behavior changed; tasks were verified by source/doc/filesystem inspection. |
+| RED confirmed | ➖ | No test files were created or modified for this docs-only change. |
+| GREEN confirmed | ⚠️ | Full pytest was not run because `ANTHROPIC_API_KEY` and `DATABASE_URL` are missing. |
+| Triangulation adequate | ➖ | Not applicable to Markdown/OpenSpec content-only changes. |
+| Safety Net for modified files | ✅ | Git inspection found no tracked or untracked application/test code changes. |
+
+**TDD Compliance**: Documentation-only applicability recorded; runtime compliance is limited by missing environment variables.
+
+---
+
+### Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 0 changed | 0 changed | pytest available |
+| Integration | 0 changed | 0 changed | pytest/httpx/FastAPI patterns present |
+| E2E | 0 | 0 | not available |
+| **Total changed test files** | **0** | **0** | |
+
+---
+
+### Changed File Coverage
+
+Coverage analysis skipped — no executable changed files and full pytest was skipped because required environment variables are missing.
+
+---
+
+### Assertion Quality
+
+**Assertion quality**: ➖ No created or modified test files to audit.
+
+---
+
+### Quality Metrics
+
+**Linter**: ➖ Not run — no Python files changed; ruff module is not available in the uv environment.  
+**Type Checker**: ➖ Not run — no Python files changed; mypy module is not available in the uv environment.
+
+### Verification Evidence
+
+| Check | Evidence | Result |
+|-------|----------|--------|
+| Required docs exist | `docs/*.md` contains exactly `README.md`, `PRD.md`, `ARCHITECTURE.md`, `DOMAIN_MODEL.md`, `RAG_STRATEGY.md`, `API_DESIGN.md`, and `IMPLEMENTATION_PLAN.md`. | ✅ Passed |
+| Lowercase PRD conflict | `docs/prd.md` glob returned no files. | ✅ Passed |
+| Tasks complete | `openspec/changes/invoice-rag-documentation/tasks.md` has 14/14 checked items. | ✅ Passed |
+| No application/runtime code modified | `git status --short`, `git diff --name-only`, and `git ls-files --others --exclude-standard` showed untracked `.atl/`, `docs/`, and `openspec/` only; no `app/`, `tests/`, `pyproject.toml`, or `uv.lock` changes. | ✅ Passed |
+| Current vs Proposed labeling | Read all seven docs and searched target terms. Auth, tenancy, object storage, vector search, embeddings, invoice chat, and RAG are labeled Proposed or explicitly stated as current limitations/not implemented. | ✅ Passed |
+| Current claims grounded in code | Grep/read checks found the documented current endpoints, invoice models, services, repositories, and tests. Searches found no implemented auth/tenant/vector/embedding/RAG/citation/object-storage surface in `app/` or `tests/` beyond unrelated `authorization_number` invoice fields. | ✅ Passed |
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test / Evidence | Result |
+|-------------|----------|-----------------|--------|
+| Documentation Set | Documentation artifacts are present | Static filesystem/doc inspection of `docs/*.md`; no app-code changes in git status/untracked inspection. | ⚠️ PARTIAL — static evidence only, no runtime test claimed |
+| Documentation Set | Lowercase PRD conflict is resolved | `docs/prd.md` absent; canonical `docs/PRD.md` present. | ⚠️ PARTIAL — static evidence only |
+| Current vs Proposed Labeling | Current behavior is documented from code | Docs cite inspected files; grep/read checks confirmed current endpoints, invoice services, domain models, repositories, and tests. | ⚠️ PARTIAL — source inspection only |
+| Current vs Proposed Labeling | Future behavior is explicitly marked | Target terms reviewed across docs; missing capabilities are labeled Proposed or current limitations. | ⚠️ PARTIAL — source/content inspection only |
+| SaaS-Ready Product Direction | Product docs communicate SaaS direction | `docs/PRD.md` and `docs/IMPLEMENTATION_PLAN.md` frame multi-user SaaS readiness as Proposed future direction. | ⚠️ PARTIAL — content inspection only |
+| SaaS-Ready Product Direction | Security boundaries are not overclaimed | Auth, tenant, ownership, and authorization references are Proposed or stated absent. | ⚠️ PARTIAL — content inspection only |
+| Reviewable Agent-Friendly Structure | Reader can find the next document | `docs/README.md` routes to product, architecture, domain, RAG, API, and plan docs. | ⚠️ PARTIAL — content inspection only |
+| Reviewable Agent-Friendly Structure | Out-of-scope behavior is clear | Docs state runtime upload, chat, auth, tenancy, vector search, RAG, migrations, object storage, embeddings, frontend, endpoints, and placeholder code are out of scope. | ⚠️ PARTIAL — content inspection only |
+
+**Compliance summary**: 8/8 scenarios statically verified; 0/8 scenarios have runtime test evidence because this is a documentation-only change and full pytest was skipped due missing required environment variables.
+
+### Correctness (Static Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Documentation Set | ✅ Implemented | All seven requested docs exist under `docs/`; no separate lowercase PRD remains. |
+| Current vs Proposed Labeling | ✅ Implemented | Missing SaaS/RAG capabilities are not presented as current behavior. |
+| SaaS-Ready Product Direction | ✅ Implemented | Product direction is represented without requiring implementation in this change. |
+| Reviewable Agent-Friendly Structure | ✅ Implemented | Docs use quick paths, summaries, tables, non-goals, and explicit status labels. |
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Current vs Proposed labeling | ✅ Yes | Substantive docs separate implemented facts from future direction. |
+| Canonical PRD path | ✅ Yes | `docs/PRD.md` exists and `docs/prd.md` is absent. |
+| Documentation structure | ✅ Yes | `docs/README.md` acts as the navigation hub; each requested doc has a focused reader job. |
+| Runtime boundary | ✅ Yes | Git inspection found no application/runtime code changes. |
+
+### Issues Found
+
+**CRITICAL**: None.
+
+**WARNING**:
+- Runtime verification was skipped: `ANTHROPIC_API_KEY` and `DATABASE_URL` are missing, so `PYTHONPATH=. uv run pytest` was not executed. No passing runtime evidence is claimed.
+- Strict TDD runtime compliance is limited for this docs-only change: apply progress records applicability evidence rather than executable RED/GREEN test evidence.
+- The documentation/OpenSpec artifacts are currently untracked (`docs/`, `openspec/`, `.atl/` appear in `git status --short`), so normal `git diff` alone would not show them.
+
+**SUGGESTION**:
+- Before archive or PR, run the full configured test command in an environment with `ANTHROPIC_API_KEY` and `DATABASE_URL` set, or add documented test-safe defaults if that is the project convention.
+- Consider declaring dev tools (`ruff`, `mypy`) in the uv dependency groups so verify can execute configured quality commands consistently.
+
+### Verdict
+
+PASS WITH WARNINGS
+
+All requested documentation artifacts and task completion checks pass static verification, and no application/runtime code changes were detected. The verdict is warning-level because strict runtime evidence could not be produced without required environment variables, and this docs-only change has no executable changed test target.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,109 @@
+schema: spec-driven
+project: ai-asistant
+persistence:
+  mode: openspec
+  initialized: 2026-06-08
+
+context: |
+  Tech stack: Python 3.12 FastAPI application using Anthropic SDK, Pydantic v2, SQLModel/SQLAlchemy asyncio, asyncpg/psycopg, pandas, pypdf, and uvicorn.
+  Architecture: Layered FastAPI architecture: API routers -> services -> infrastructure, with schemas/models/core/utils and an agent tool registry loop.
+  Testing: pytest with pytest-asyncio; HTTP integration tests use FastAPI TestClient and httpx ASGITransport; repository tests use aiosqlite in-memory database fixtures.
+  Style: Ruff line length 80, pycodestyle/pyflakes/isort/bugbear/pyupgrade rules, MyPy strict with Pydantic plugin, conventional commits on develop.
+
+decisions:
+  execution_mode: interactive
+  artifact_store:
+    mode: openspec
+  chained_pr_strategy: ask-always
+  review_budget_lines: 400
+
+strict_tdd: true
+
+testing:
+  strict_tdd: true
+  strict_tdd_source: test-runner-fallback
+  detected: 2026-06-08
+  runner:
+    available: true
+    framework: pytest + pytest-asyncio
+    command: PYTHONPATH=. uv run pytest
+    configured_command: make test
+    notes:
+      - make test runs plain pytest and may require an activated environment plus PYTHONPATH including the project root.
+      - uv run pytest initially failed to import app without PYTHONPATH.
+      - PYTHONPATH=. uv run pytest reached settings validation and requires ANTHROPIC_API_KEY and DATABASE_URL or test-safe defaults.
+  layers:
+    unit:
+      available: true
+      tool: pytest
+      evidence:
+        - tests/test_invoice_models.py
+        - tests/test_invoice_service.py
+    integration:
+      available: true
+      tool: pytest + httpx ASGITransport + FastAPI TestClient + aiosqlite
+      evidence:
+        - tests/conftest.py
+        - tests/test_health.py
+        - tests/test_invoice_upload.py
+        - tests/test_repositories.py
+    e2e:
+      available: false
+      tool: null
+      evidence: []
+  coverage:
+    available: true
+    tool: pytest-cov
+    command: PYTHONPATH=. uv run pytest --cov=app
+    configured_command: null
+  quality:
+    linter:
+      available: true
+      tool: ruff
+      command: make lint
+      verified: false
+      notes:
+        - uv run ruff check . failed because ruff is not declared in project dependencies or dev dependency-groups.
+    type_checker:
+      available: true
+      tool: mypy strict + pydantic.mypy
+      command: make type
+      verified: false
+      notes:
+        - uv run mypy app failed because mypy is not declared in project dependencies or dev dependency-groups.
+    formatter:
+      available: true
+      tool: ruff format
+      command: make format
+
+rules:
+  proposal:
+    - Keep proposals focused on one reviewable change.
+    - Include rollback plan for risky API, persistence, or external-service changes.
+    - Respect review_budget_lines: 400 and ask before choosing a chained PR strategy.
+  specs:
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY).
+    - Use Given/When/Then for scenarios.
+    - Keep generated technical artifacts in English.
+  design:
+    - Follow the existing layered architecture: API -> services -> infrastructure.
+    - Document dependencies on Anthropic, database access, file parsing, and streaming behavior explicitly.
+    - Prefer async-first designs consistent with existing FastAPI services.
+  tasks:
+    - Group tasks by phase and keep each task completable in one session.
+    - Keep tests with the task they verify.
+    - Flag changes likely to exceed 400 changed lines before implementation.
+  apply:
+    - Follow existing code patterns and FastAPI dependency-injection conventions.
+    - Run RED-GREEN-REFACTOR unless the user explicitly disables Strict TDD.
+    tdd: true
+    test_command: PYTHONPATH=. uv run pytest
+  verify:
+    test_command: PYTHONPATH=. uv run pytest
+    build_command: uv run mypy app
+    coverage_threshold: 0
+    notes:
+      - Verification currently requires environment variables for settings and missing dev tools to be installed or declared.
+  archive:
+    - Warn before merging destructive deltas.
+    - Archive completed changes under openspec/changes/archive/YYYY-MM-DD-{change-name}/.

--- a/openspec/specs/invoice-rag-documentation/spec.md
+++ b/openspec/specs/invoice-rag-documentation/spec.md
@@ -1,0 +1,97 @@
+# Invoice RAG Documentation Specification
+
+## Purpose
+
+This capability defines a documentation-only baseline for the invoice assistant.
+The documentation MUST describe implemented invoice ingestion and AI summary
+behavior accurately, while marking SaaS, tenancy, invoice chat, and RAG
+capabilities as Proposed when they are not implemented.
+
+## Requirements
+
+### Requirement: Documentation Set
+
+The change MUST create the requested documentation set under `docs/` and MUST
+avoid application runtime behavior changes.
+
+| Document | Required focus |
+|----------|----------------|
+| `docs/README.md` | Navigation hub for the documentation set. |
+| `docs/PRD.md` | Product direction and Current vs Proposed scope. |
+| `docs/ARCHITECTURE.md` | Current FastAPI architecture and proposed SaaS/RAG evolution. |
+| `docs/DOMAIN_MODEL.md` | Current invoice entities and proposed document/RAG concepts. |
+| `docs/RAG_STRATEGY.md` | Proposed retrieval, chunking, embeddings, grounding, and citations. |
+| `docs/API_DESIGN.md` | Current endpoints and proposed API direction. |
+| `docs/IMPLEMENTATION_PLAN.md` | Phased, reviewable implementation path. |
+
+#### Scenario: Documentation artifacts are present
+
+- GIVEN the documentation change is applied
+- WHEN a reviewer inspects `docs/`
+- THEN each required document MUST exist with the required focus
+- AND no app code change SHALL be required by this capability
+
+#### Scenario: Lowercase PRD conflict is resolved
+
+- GIVEN `docs/prd.md` exists before the change
+- WHEN the documentation set is created
+- THEN the canonical PRD MUST be `docs/PRD.md`
+- AND conflicting lowercase PRD content MUST NOT remain as a separate source
+
+### Requirement: Current vs Proposed Labeling
+
+The documentation MUST distinguish Current implementation from Proposed product
+direction and MUST NOT present missing SaaS/RAG capabilities as existing.
+
+#### Scenario: Current behavior is documented from code
+
+- GIVEN docs describe invoice upload, persistence, or batch AI analysis
+- WHEN the behavior is labeled Current
+- THEN the description MUST be supported by inspected code or tests
+- AND unsupported assumptions MUST NOT be stated as facts
+
+#### Scenario: Future behavior is explicitly marked
+
+- GIVEN docs mention authentication, tenancy, invoice chat, vector search,
+  embeddings, object storage, migrations, or RAG retrieval
+- WHEN those capabilities are not present in the codebase
+- THEN the docs MUST label them as Proposed
+- AND readers MUST be able to tell they are not implemented today
+
+### Requirement: SaaS-Ready Product Direction
+
+The documentation SHOULD frame future product decisions for a multi-user SaaS
+invoice assistant without requiring those features in this change.
+
+#### Scenario: Product docs communicate SaaS direction
+
+- GIVEN a future agent reads the PRD or implementation plan
+- WHEN they look for product direction
+- THEN the docs SHOULD identify multi-user SaaS readiness as the target
+- AND SHOULD separate future tenant/security work from current behavior
+
+#### Scenario: Security boundaries are not overclaimed
+
+- GIVEN docs describe user ownership, authorization, or tenant isolation
+- WHEN those mechanisms are not implemented
+- THEN the docs MUST present them as Proposed boundaries
+- AND MUST NOT imply current production-grade isolation
+
+### Requirement: Reviewable Agent-Friendly Structure
+
+The documentation MUST reduce cognitive load for human reviewers and future AI
+coding agents through concise structure, summaries, tables, and explicit
+non-goals.
+
+#### Scenario: Reader can find the next document
+
+- GIVEN a reader starts at `docs/README.md`
+- WHEN they need product, architecture, domain, RAG, API, or plan details
+- THEN the README MUST route them to the relevant document
+
+#### Scenario: Out-of-scope behavior is clear
+
+- GIVEN a reviewer checks the documentation change
+- WHEN they look for implementation impact
+- THEN the docs MUST state that runtime upload, chat, authentication, tenancy,
+  vector search, and RAG behavior are out of scope for this change


### PR DESCRIPTION
Closes #3

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds product and technical documentation for the invoice upload, chat, and future RAG direction.
- Documents Current vs Proposed behavior so future agents do not treat planned SaaS/RAG features as implemented.
- Archives the completed SDD planning trail for this documentation change.

## Changes
| File | Change |
|------|--------|
| `docs/` | Added README, PRD, architecture, domain model, RAG strategy, API design, and implementation plan docs. |
| `openspec/config.yaml` | Added OpenSpec project configuration. |
| `openspec/specs/invoice-rag-documentation/spec.md` | Added source-of-truth spec for the documentation capability. |
| `openspec/changes/archive/2026-06-10-invoice-rag-documentation/` | Archived SDD proposal, exploration, design, tasks, verification, and archive report. |

## Test Plan
- [x] Verified all seven required docs exist.
- [x] Verified Current vs Proposed labeling for SaaS/RAG/auth/tenancy/vector/object-storage concepts.
- [x] Verified no application/runtime code changes were included.
- [ ] Full pytest not run: `ANTHROPIC_API_KEY` and `DATABASE_URL` are required and not available locally.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Ran shellcheck on modified scripts, or confirmed no scripts changed.
- [x] Docs updated if behavior changed.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.